### PR TITLE
perf: use MediaQuery.sizeOf instead of MediaQuery.of

### DIFF
--- a/lib/src/hydra_widget.dart
+++ b/lib/src/hydra_widget.dart
@@ -55,7 +55,7 @@ class HydraWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final width = comparableWidth(MediaQuery.of(context).size);
+    final width = comparableWidth(MediaQuery.sizeOf(context));
     return nearestWidget(width).widget;
   }
 


### PR DESCRIPTION
## Summary

- Replace `MediaQuery.of(context).size` with `MediaQuery.sizeOf(context)` in `HydraWidget.build()`
- Reduces unnecessary widget rebuilds when unrelated MediaQuery properties change (e.g. keyboard opening changes `viewInsets` but not `size`)

## Test plan

- [x] All existing tests pass
- [x] `flutter analyze` clean

Closes #5