### PR TITLE
chore: migrate from flutter_lints to very_good_analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![CI](https://github.com/igoriuz/hydra/actions/workflows/ci.yml/badge.svg)](https://github.com/igoriuz/hydra/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/igoriuz/hydra/branch/main/graph/badge.svg)](https://codecov.io/gh/igoriuz/hydra)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![style: very good analysis](https://img.shields.io/badge/style-very_good_analysis-B22C89.svg)](https://pub.dev/packages/very_good_analysis)
 
 Responsive layouts are like the Hydra of Greek mythology - cut off one screen size and two more appear. Phone, tablet, foldable, desktop, ultrawide... every time you think you've handled them all, a new head grows.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:very_good_analysis/analysis_options.yaml
 
 analyzer:
   exclude:

--- a/lib/hydra.dart
+++ b/lib/hydra.dart
@@ -4,5 +4,5 @@ library;
 export 'package:hydra/src/breakpoint.dart';
 export 'package:hydra/src/hydra_behaviour.dart';
 export 'package:hydra/src/hydra_head.dart';
-export 'package:hydra/src/hydra_widget.dart';
 export 'package:hydra/src/hydra_no_widget_exception.dart';
+export 'package:hydra/src/hydra_widget.dart';

--- a/lib/src/hydra_behaviour.dart
+++ b/lib/src/hydra_behaviour.dart
@@ -10,7 +10,7 @@ const double kMediumBP = 900;
 const double kLargeBP = 1200;
 
 /// {@template hydra_behaviour}
-/// [HydraBehaviour] defines behaviour for [HydraWidget].
+/// [HydraBehaviour] defines behaviour for `HydraWidget`.
 ///
 /// In order to decide which device type is used, [HydraBehaviour] exposes
 /// [HydraBehaviour.breakpointSmall], [HydraBehaviour.breakpointMedium] and
@@ -36,21 +36,6 @@ const double kLargeBP = 1200;
 /// Default breakpoints are defined in [kSmallBP], [kMediumBP] and [kLargeBP].
 /// {@endtemplate}
 class HydraBehaviour {
-  /// Breakpoint threshold between [Breakpoint.mini] and [Breakpoint.small].
-  final double breakpointSmall;
-
-  /// Breakpoint threshold between [Breakpoint.small] and [Breakpoint.medium].
-  final double breakpointMedium;
-
-  /// Breakpoint threshold between [Breakpoint.medium] and [Breakpoint.large].
-  final double breakpointLarge;
-
-  /// Whether the widget should re-evaluate when device orientation changes.
-  final bool isOrientationAware;
-
-  /// Whether to prefer smaller screen alternatives when no exact match exists.
-  final bool isSmallerScreenPreferred;
-
   /// {@macro hydra_behaviour}
   const HydraBehaviour({
     this.breakpointSmall = kSmallBP,
@@ -58,21 +43,33 @@ class HydraBehaviour {
     this.breakpointLarge = kLargeBP,
     this.isOrientationAware = true,
     this.isSmallerScreenPreferred = false,
-  })  : assert(breakpointSmall < breakpointMedium),
-        assert(breakpointMedium < breakpointLarge);
+  })  : assert(
+          breakpointSmall < breakpointMedium,
+          'breakpointSmall must be less than breakpointMedium',
+        ),
+        assert(
+          breakpointMedium < breakpointLarge,
+          'breakpointMedium must be less than breakpointLarge',
+        );
 
-  /// Default behaviour except that [isSmallerScreenPreferred] is set to `true`.
+  /// Default behaviour except [isSmallerScreenPreferred] is set to `true`.
   const HydraBehaviour.preferSmaller({
     this.breakpointSmall = kSmallBP,
     this.breakpointMedium = kMediumBP,
     this.breakpointLarge = kLargeBP,
     this.isOrientationAware = true,
   })  : isSmallerScreenPreferred = true,
-        assert(breakpointSmall < breakpointMedium),
-        assert(breakpointMedium < breakpointLarge);
+        assert(
+          breakpointSmall < breakpointMedium,
+          'breakpointSmall must be less than breakpointMedium',
+        ),
+        assert(
+          breakpointMedium < breakpointLarge,
+          'breakpointMedium must be less than breakpointLarge',
+        );
 
   /// Default behaviour except that the shortest side will be used. This means
-  /// that even when the device is rotated, [HydraWidget] won't choose a
+  /// that even when the device is rotated, `HydraWidget` won't choose a
   /// different screen alternative.
   const HydraBehaviour.noOrientation({
     this.breakpointSmall = kSmallBP,
@@ -80,8 +77,14 @@ class HydraBehaviour {
     this.breakpointLarge = kLargeBP,
     this.isSmallerScreenPreferred = false,
   })  : isOrientationAware = false,
-        assert(breakpointSmall < breakpointMedium),
-        assert(breakpointMedium < breakpointLarge);
+        assert(
+          breakpointSmall < breakpointMedium,
+          'breakpointSmall must be less than breakpointMedium',
+        ),
+        assert(
+          breakpointMedium < breakpointLarge,
+          'breakpointMedium must be less than breakpointLarge',
+        );
 
   /// Breakpoints based on Material Design layout guidelines.
   ///
@@ -97,4 +100,19 @@ class HydraBehaviour {
   })  : breakpointSmall = 600,
         breakpointMedium = 840,
         breakpointLarge = 1200;
+
+  /// Breakpoint threshold between [Breakpoint.mini] and [Breakpoint.small].
+  final double breakpointSmall;
+
+  /// Breakpoint threshold between [Breakpoint.small] and [Breakpoint.medium].
+  final double breakpointMedium;
+
+  /// Breakpoint threshold between [Breakpoint.medium] and [Breakpoint.large].
+  final double breakpointLarge;
+
+  /// Whether the widget should re-evaluate when device orientation changes.
+  final bool isOrientationAware;
+
+  /// Whether to prefer smaller screen alternatives when no exact match exists.
+  final bool isSmallerScreenPreferred;
 }

--- a/lib/src/hydra_head.dart
+++ b/lib/src/hydra_head.dart
@@ -1,18 +1,13 @@
 import 'package:flutter/material.dart';
 
-import 'breakpoint.dart';
+import 'package:hydra/src/breakpoint.dart';
 
 /// {@template hydra_head}
 /// [HydraHead] pairs a [widget] with a [breakpoint] to define which device
 /// type the widget is intended for.
 /// {@endtemplate}
 class HydraHead {
-  /// The widget to display for this breakpoint.
-  final Widget widget;
-
-  /// The device type breakpoint this head targets.
-  final Breakpoint breakpoint;
-
+  /// {@macro hydra_head}
   const HydraHead._(this.widget, this.breakpoint);
 
   /// Creates a [HydraHead] targeting [Breakpoint.mini].
@@ -26,6 +21,12 @@ class HydraHead {
 
   /// Creates a [HydraHead] targeting [Breakpoint.large].
   const factory HydraHead.large(Widget widget) = _LargeHead;
+
+  /// The widget to display for this breakpoint.
+  final Widget widget;
+
+  /// The device type breakpoint this head targets.
+  final Breakpoint breakpoint;
 }
 
 class _MiniHead extends HydraHead {

--- a/lib/src/hydra_no_widget_exception.dart
+++ b/lib/src/hydra_no_widget_exception.dart
@@ -1,10 +1,10 @@
-/// Exception thrown when no widget was provided to [HydraWidget].
+/// Exception thrown when no widget was provided to a `HydraWidget`.
 class HydraNoWidgetException implements Exception {
-  /// The error message.
-  final String message;
-
   /// Creates a [HydraNoWidgetException] with the given [message].
   const HydraNoWidgetException(this.message);
+
+  /// The error message.
+  final String message;
 
   @override
   String toString() => 'HydraNoWidgetException: $message';

--- a/lib/src/hydra_widget.dart
+++ b/lib/src/hydra_widget.dart
@@ -1,22 +1,18 @@
 import 'package:flutter/material.dart';
-
-import 'breakpoint.dart';
-import 'hydra_behaviour.dart';
-import 'hydra_head.dart';
-import 'hydra_no_widget_exception.dart';
+import 'package:hydra/src/breakpoint.dart';
+import 'package:hydra/src/hydra_behaviour.dart';
+import 'package:hydra/src/hydra_head.dart';
+import 'package:hydra/src/hydra_no_widget_exception.dart';
 
 /// [HydraWidget] is a [StatelessWidget] that selects which widget to display
 /// based on the current screen size and [behaviour] configuration.
 ///
-/// Up to four screen alternatives are supported: [mini], [small], [medium],
-/// and [large]. At least one must be provided.
+/// Up to four screen alternatives are supported: `mini`, `small`, `medium`,
+/// and `large`. At least one must be provided.
 class HydraWidget extends StatelessWidget {
-  /// {@macro hydra_behaviour}
-  final HydraBehaviour behaviour;
-
-  /// The resolved list of widget alternatives, ordered by preference.
-  final List<HydraHead> widgets;
-
+  /// Creates a [HydraWidget] with the given screen alternatives.
+  ///
+  /// At least one of [mini], [small], [medium], or [large] must be provided.
   HydraWidget({
     super.key,
     this.behaviour = const HydraBehaviour(),
@@ -31,6 +27,12 @@ class HydraWidget extends StatelessWidget {
           large: large,
           preferSmaller: behaviour.isSmallerScreenPreferred,
         );
+
+  /// {@macro hydra_behaviour}
+  final HydraBehaviour behaviour;
+
+  /// The resolved list of widget alternatives, ordered by preference.
+  final List<HydraHead> widgets;
 
   static List<HydraHead> _buildWidgetList({
     required Widget? mini,
@@ -47,7 +49,7 @@ class HydraWidget extends StatelessWidget {
     ];
 
     if (heads.isEmpty) {
-      throw HydraNoWidgetException('At least one widget is needed');
+      throw const HydraNoWidgetException('At least one widget is needed');
     }
 
     return preferSmaller ? heads.reversed.toList() : heads;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  very_good_analysis: ^7.0.0

--- a/test/hydra_behaviour_test.dart
+++ b/test/hydra_behaviour_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('HydraBehaviour', () {
     group('default constructor', () {
       test('has correct default values', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour();
 
         expect(behaviour.breakpointSmall, kSmallBP);
@@ -16,7 +16,7 @@ void main() {
       });
 
       test('accepts custom breakpoints', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour(
           breakpointSmall: 400,
           breakpointMedium: 800,
@@ -30,16 +30,16 @@ void main() {
 
       test('asserts when breakpointSmall >= breakpointMedium', () {
         expect(
-          // ignore: prefer_const_constructors
-          () => HydraBehaviour(breakpointSmall: 900, breakpointMedium: 900),
+          // ignore: prefer_const_constructors, non-const needed for coverage
+          () => HydraBehaviour(breakpointSmall: 900),
           throwsA(isA<AssertionError>()),
         );
       });
 
       test('asserts when breakpointMedium >= breakpointLarge', () {
         expect(
-          // ignore: prefer_const_constructors
-          () => HydraBehaviour(breakpointMedium: 1200, breakpointLarge: 1200),
+          // ignore: prefer_const_constructors, non-const needed for coverage
+          () => HydraBehaviour(breakpointMedium: 1200),
           throwsA(isA<AssertionError>()),
         );
       });
@@ -47,7 +47,7 @@ void main() {
 
     group('preferSmaller', () {
       test('has isSmallerScreenPreferred set to true', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour.preferSmaller();
 
         expect(behaviour.isSmallerScreenPreferred, isTrue);
@@ -58,7 +58,7 @@ void main() {
       });
 
       test('accepts custom breakpoints', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour.preferSmaller(
           breakpointSmall: 500,
           breakpointMedium: 700,
@@ -72,10 +72,7 @@ void main() {
 
       test('asserts when breakpointSmall >= breakpointMedium', () {
         expect(
-          () => HydraBehaviour.preferSmaller(
-            breakpointSmall: 900,
-            breakpointMedium: 900,
-          ),
+          () => HydraBehaviour.preferSmaller(breakpointSmall: 900),
           throwsA(isA<AssertionError>()),
         );
       });
@@ -83,7 +80,7 @@ void main() {
 
     group('noOrientation', () {
       test('has isOrientationAware set to false', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour.noOrientation();
 
         expect(behaviour.isOrientationAware, isFalse);
@@ -94,7 +91,7 @@ void main() {
       });
 
       test('accepts custom breakpoints', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour.noOrientation(
           breakpointSmall: 450,
           breakpointMedium: 850,
@@ -108,10 +105,7 @@ void main() {
 
       test('asserts when breakpointMedium >= breakpointLarge', () {
         expect(
-          () => HydraBehaviour.noOrientation(
-            breakpointMedium: 1200,
-            breakpointLarge: 1200,
-          ),
+          () => HydraBehaviour.noOrientation(breakpointMedium: 1200),
           throwsA(isA<AssertionError>()),
         );
       });
@@ -119,7 +113,7 @@ void main() {
 
     group('material', () {
       test('uses Material Design breakpoints', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour.material();
 
         expect(behaviour.breakpointSmall, 600);
@@ -130,7 +124,7 @@ void main() {
       });
 
       test('accepts custom flags', () {
-        // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors, non-const needed for coverage
         final behaviour = HydraBehaviour.material(
           isOrientationAware: false,
           isSmallerScreenPreferred: true,

--- a/test/hydra_no_widget_exception_test.dart
+++ b/test/hydra_no_widget_exception_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('HydraNoWidgetException', () {
     test('throws when no widgets are given', () {
       expect(
-        () => HydraWidget(),
+        HydraWidget.new,
         throwsA(isA<HydraNoWidgetException>()),
       );
     });

--- a/test/hydra_test.dart
+++ b/test/hydra_test.dart
@@ -18,32 +18,47 @@ void main() {
         expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.mini);
       });
 
-      test('returns small when only small is available at large breakpoint',
-          () {
-        const screenBP = kLargeBP;
-        final hydra = HydraWidget(small: small);
+      test(
+        'returns small when only small is available at large breakpoint',
+        () {
+          const screenBP = kLargeBP;
+          final hydra = HydraWidget(small: small);
 
-        expect(hydra.widgets.length, 1);
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.small);
-      });
+          expect(hydra.widgets.length, 1);
+          expect(
+            hydra.nearestWidget(screenBP).breakpoint,
+            Breakpoint.small,
+          );
+        },
+      );
 
-      test('returns medium when only medium is available at small breakpoint',
-          () {
-        const screenBP = kSmallBP;
-        final hydra = HydraWidget(medium: medium);
+      test(
+        'returns medium when only medium is available at small breakpoint',
+        () {
+          const screenBP = kSmallBP;
+          final hydra = HydraWidget(medium: medium);
 
-        expect(hydra.widgets.length, 1);
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.medium);
-      });
+          expect(hydra.widgets.length, 1);
+          expect(
+            hydra.nearestWidget(screenBP).breakpoint,
+            Breakpoint.medium,
+          );
+        },
+      );
 
-      test('returns large when only large is available at large breakpoint',
-          () {
-        const screenBP = kLargeBP;
-        final hydra = HydraWidget(large: large);
+      test(
+        'returns large when only large is available at large breakpoint',
+        () {
+          const screenBP = kLargeBP;
+          final hydra = HydraWidget(large: large);
 
-        expect(hydra.widgets.length, 1);
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.large);
-      });
+          expect(hydra.widgets.length, 1);
+          expect(
+            hydra.nearestWidget(screenBP).breakpoint,
+            Breakpoint.large,
+          );
+        },
+      );
     });
 
     group('next bigger screen', () {
@@ -65,65 +80,91 @@ void main() {
 
       test('large if only [mini, small, large] at medium breakpoint', () {
         const screenBP = kMediumBP;
-        final hydra = HydraWidget(mini: mini, small: small, large: large);
+        final hydra = HydraWidget(
+          mini: mini,
+          small: small,
+          large: large,
+        );
 
         expect(hydra.widgets.length, 3);
         expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.large);
       });
 
       test(
-          'small if only [mini, small, large] at width between small and medium',
-          () {
-        const screenBP = kSmallBP + 5;
-        final hydra = HydraWidget(mini: mini, small: small, large: large);
+        'small if only [mini, small, large] at width between small '
+        'and medium',
+        () {
+          const screenBP = kSmallBP + 5;
+          final hydra = HydraWidget(
+            mini: mini,
+            small: small,
+            large: large,
+          );
 
-        expect(hydra.widgets.length, 3);
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.small);
-      });
+          expect(hydra.widgets.length, 3);
+          expect(
+            hydra.nearestWidget(screenBP).breakpoint,
+            Breakpoint.small,
+          );
+        },
+      );
     });
 
     group('orientation awareness', () {
-      test('uses shortestSide when orientation awareness is off (vertical)',
-          () {
-        const verticalSize = Size(300, 700);
-        final hydra = HydraWidget(
-          mini: mini,
-          behaviour: const HydraBehaviour.noOrientation(),
-        );
-        expect(hydra.comparableWidth(verticalSize), verticalSize.shortestSide);
-      });
-
-      test('uses shortestSide when orientation awareness is off (horizontal)',
-          () {
-        const horizontalSize = Size(700, 300);
-        final hydra = HydraWidget(
-          mini: mini,
-          behaviour: const HydraBehaviour.noOrientation(),
-        );
-        expect(
-            hydra.comparableWidth(horizontalSize), horizontalSize.shortestSide);
-      });
-
-      test('uses shortestSide for vertical device when orientation aware', () {
-        const verticalSize = Size(300, 700);
-        final hydra = HydraWidget(
-          mini: mini,
-          behaviour: const HydraBehaviour(isOrientationAware: true),
-        );
-        expect(hydra.comparableWidth(verticalSize), verticalSize.shortestSide);
-      });
+      test(
+        'uses shortestSide when orientation awareness is off (vertical)',
+        () {
+          const verticalSize = Size(300, 700);
+          final hydra = HydraWidget(
+            mini: mini,
+            behaviour: const HydraBehaviour.noOrientation(),
+          );
+          expect(
+            hydra.comparableWidth(verticalSize),
+            verticalSize.shortestSide,
+          );
+        },
+      );
 
       test(
-          'uses width (longestSide) for horizontal device when orientation aware',
-          () {
-        const horizontalSize = Size(700, 300);
-        final hydra = HydraWidget(
-          mini: mini,
-          behaviour: const HydraBehaviour(isOrientationAware: true),
-        );
-        expect(
-            hydra.comparableWidth(horizontalSize), horizontalSize.longestSide);
-      });
+        'uses shortestSide when orientation awareness is off (horizontal)',
+        () {
+          const horizontalSize = Size(700, 300);
+          final hydra = HydraWidget(
+            mini: mini,
+            behaviour: const HydraBehaviour.noOrientation(),
+          );
+          expect(
+            hydra.comparableWidth(horizontalSize),
+            horizontalSize.shortestSide,
+          );
+        },
+      );
+
+      test(
+        'uses shortestSide for vertical device when orientation aware',
+        () {
+          const verticalSize = Size(300, 700);
+          final hydra = HydraWidget(mini: mini);
+          expect(
+            hydra.comparableWidth(verticalSize),
+            verticalSize.shortestSide,
+          );
+        },
+      );
+
+      test(
+        'uses width (longestSide) for horizontal device when '
+        'orientation aware',
+        () {
+          const horizontalSize = Size(700, 300);
+          final hydra = HydraWidget(mini: mini);
+          expect(
+            hydra.comparableWidth(horizontalSize),
+            horizontalSize.longestSide,
+          );
+        },
+      );
     });
 
     group('prefer smaller screen', () {
@@ -139,17 +180,20 @@ void main() {
       });
 
       test(
-          'large if only [mini, large] at medium breakpoint (bigger preferred)',
-          () {
-        const screenBP = kMediumBP;
-        final hydra = HydraWidget(
-          mini: mini,
-          large: large,
-          behaviour: const HydraBehaviour(isSmallerScreenPreferred: false),
-        );
+        'large if only [mini, large] at medium breakpoint (bigger preferred)',
+        () {
+          const screenBP = kMediumBP;
+          final hydra = HydraWidget(
+            mini: mini,
+            large: large,
+          );
 
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.large);
-      });
+          expect(
+            hydra.nearestWidget(screenBP).breakpoint,
+            Breakpoint.large,
+          );
+        },
+      );
     });
 
     group('exact breakpoint match', () {
@@ -173,7 +217,10 @@ void main() {
           behaviour: const HydraBehaviour.preferSmaller(),
         );
 
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.medium);
+        expect(
+          hydra.nearestWidget(screenBP).breakpoint,
+          Breakpoint.medium,
+        );
       });
 
       test('small at medium width with smaller preferred', () {
@@ -194,7 +241,6 @@ void main() {
           small: small,
           mini: mini,
           large: large,
-          behaviour: const HydraBehaviour(isSmallerScreenPreferred: false),
         );
 
         expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.large);
@@ -206,7 +252,6 @@ void main() {
           small: small,
           mini: mini,
           large: large,
-          behaviour: const HydraBehaviour(isSmallerScreenPreferred: false),
         );
 
         expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.mini);
@@ -221,12 +266,17 @@ void main() {
           behaviour: const HydraBehaviour(isSmallerScreenPreferred: true),
         );
 
-        expect(hydra.nearestWidget(screenBP).breakpoint, Breakpoint.medium);
+        expect(
+          hydra.nearestWidget(screenBP).breakpoint,
+          Breakpoint.medium,
+        );
       });
     });
 
     group('build', () {
-      testWidgets('renders the correct widget via MediaQuery', (tester) async {
+      testWidgets('renders the correct widget via MediaQuery', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           MediaQuery(
             data: const MediaQueryData(size: Size(1400, 900)),


### PR DESCRIPTION
## Summary

- Replace `flutter_lints` with `very_good_analysis` for stricter linting
- Fix all lint warnings: `sort_constructors_first`, `always_use_package_imports`, `prefer_asserts_with_message`, `comment_references`, `public_member_api_docs`, `prefer_const_constructors`, `require_trailing_commas`, `lines_longer_than_80_chars`, `avoid_redundant_argument_values`, `unnecessary_lambdas`
- Add very good analysis badge to README

## Test plan

- [x] `flutter analyze` - 0 issues
- [x] All tests pass
- [x] `dart format --set-exit-if-changed .` - no changes needed

Closes #6